### PR TITLE
Delta

### DIFF
--- a/include/TypeZoo/DeltaMap.hpp
+++ b/include/TypeZoo/DeltaMap.hpp
@@ -1,5 +1,5 @@
-#ifndef DELTASETMAP_H
-#define DELTASETMAP_H
+#ifndef DELTAMAP_H
+#define DELTAMAP_H
 
 #include "DeltaSet.hpp"
 #include <map>
@@ -7,7 +7,7 @@
 #include "merges/map_mrg.hpp"
 
 template <typename k_type, class T, class Func>
-class DeltaSetMap {
+class DeltaMap {
 public:
 
 	//type alias
@@ -16,12 +16,12 @@ public:
 	using mapped_type = Lattice<T, Func>;
 	using value_type = std::pair<k_type, Lattice<T, Func>>;
 	using size_type = std::size_t;
-	using delta_type = Lattice<DeltaSetMap<k_type, T, Func>, MapUnion>;
+	using delta_type = Lattice<DeltaMap<k_type, T, Func>, MapUnion>;
 
-	DeltaSetMap() : _base(std::map<k_type, Lattice<T, Func>>{}) {};
+	DeltaMap() : _base(std::map<k_type, Lattice<T, Func>>{}) {};
 
 	//copy constructor
-	DeltaSetMap(const std::map<k_type, Lattice<T, Func>>& base) : _base(base) {};
+	DeltaMap(const std::map<k_type, Lattice<T, Func>>& base) : _base(base) {};
 
 	
 	iterator begin() {
@@ -65,14 +65,14 @@ public:
 		return _base.emplace(args...);
 	}
 
-	bool operator==(const DeltaSetMap<k_type, T, Func>& right) const {
+	bool operator==(const DeltaMap<k_type, T, Func>& right) const {
 		return _base == right._base;
 	}
 
 	template <class Q=T>
 	typename std::enable_if_t<has_delta<Q>::value, delta_type>
 	get_delta() {
-		DeltaSetMap<k_type, Q, Func> delta;
+		DeltaMap<k_type, Q, Func> delta;
 		
 		for (auto& [key, value] : _base) {
 			delta.insert(std::make_pair(key, value.get_delta()));
@@ -85,4 +85,4 @@ private:
 	std::map<k_type, Lattice<T, Func>> _base;
 };
 
-#endif // DELTASETMAP_H
+#endif // DELTAMAP_H

--- a/include/TypeZoo/DeltaSet.hpp
+++ b/include/TypeZoo/DeltaSet.hpp
@@ -31,10 +31,11 @@ public:
        }
     }
 
-    void insert(const _KeyType& key) {
+    std::pair<iterator, bool> insert(const value_type& key) {
         if (!_base.count(key)) {
-            _delta.insert(key);
+            return _delta.insert(key);
        }
+        return _base.insert(key);
     }
 
     delta_type get_delta() {
@@ -59,6 +60,13 @@ public:
     iterator end() {
         iterator result(_delta.end());
         return result;
+    }
+
+    //current definition require both base and delta to be exactly
+    //the same. Maybe we should relax this is to only require the
+    //union of _base and _delta to be the same?
+    bool operator==(const DeltaSet<_KeyType>& right) const {
+        return (_base == right._base) && (_delta == right._delta);
     }
 
     void rebase() {

--- a/include/TypeZoo/DeltaSet.hpp
+++ b/include/TypeZoo/DeltaSet.hpp
@@ -15,11 +15,14 @@ public:
     // move constructor
     DeltaSet(const std::set<_KeyType>&& base) : _base(std::move(base)), _delta(std::set<_KeyType>{}) {};
 
+    //type alias
     // return type of get_delta
     using delta_type = DeltaSet<_KeyType>;
-
     // type returned by dereferencing the iterator type
     using value_type = _KeyType;
+    using iterator = DeltaIterator<std::set<_KeyType>>;
+    using size_type = std::size_t;
+
 
     void merge(DeltaSet<_KeyType>& __src) {
        // make a copy of all the keys here, need a way to avoid this
@@ -40,21 +43,21 @@ public:
         return delta;
     }
 
-    int size() const {
+    size_type size() const {
         return _base.size() + _delta.size();
     }
 
-    int count(const _KeyType& key) const {
+    size_type count(const _KeyType& key) const {
         return _base.count(key) + _delta.count(key);
     }
 
-    DeltaIterator<std::set<_KeyType>> begin() {
-        DeltaIterator<std::set<_KeyType>> result(_base.begin(), _base.end(), _delta.begin(), _delta.end());
+    iterator begin() {
+        iterator result(_base.begin(), _base.end(), _delta.begin(), _delta.end());
         return result;
     }
 
-    DeltaIterator<std::set<_KeyType>> end() {
-        DeltaIterator<std::set<_KeyType>> result(_delta.end());
+    iterator end() {
+        iterator result(_delta.end());
         return result;
     }
 

--- a/include/TypeZoo/DeltaSetMap.hpp
+++ b/include/TypeZoo/DeltaSetMap.hpp
@@ -6,22 +6,22 @@
 #include "lattice_core.hpp"
 #include "merges/map_mrg.hpp"
 
-template <typename k_type, typename set_v_type, class Func>
+template <typename k_type, class T, class Func>
 class DeltaSetMap {
 public:
 
 	//type alias
-	using iterator = typename std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>::iterator;
+	using iterator = typename std::map<k_type, Lattice<T, Func>>::iterator;
 	using key_type = k_type;
-	using mapped_type = Lattice<DeltaSet<set_v_type>, Func>;
-	using value_type = std::pair<k_type, Lattice<DeltaSet<set_v_type>, Func>>;
+	using mapped_type = Lattice<T, Func>;
+	using value_type = std::pair<k_type, Lattice<T, Func>>;
 	using size_type = std::size_t;
-	using delta_type = Lattice<DeltaSetMap<k_type, set_v_type, Func>, MapUnion>;
+	using delta_type = Lattice<DeltaSetMap<k_type, T, Func>, MapUnion>;
 
-	DeltaSetMap() : _base(std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>{}) {};
+	DeltaSetMap() : _base(std::map<k_type, Lattice<T, Func>>{}) {};
 
 	//copy constructor
-	DeltaSetMap(const std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>& base) : _base(base) {};
+	DeltaSetMap(const std::map<k_type, Lattice<T, Func>>& base) : _base(base) {};
 
 	
 	iterator begin() {
@@ -65,12 +65,14 @@ public:
 		return _base.emplace(args...);
 	}
 
-	bool operator==(const DeltaSetMap<k_type, set_v_type, Func>& right) const {
+	bool operator==(const DeltaSetMap<k_type, T, Func>& right) const {
 		return _base == right._base;
 	}
 
-	delta_type get_delta() {
-		DeltaSetMap<k_type, set_v_type, Func> delta;
+	template <class Q=T>
+	typename std::enable_if_t<has_delta<Q>::value, delta_type>
+	get_delta() {
+		DeltaSetMap<k_type, Q, Func> delta;
 		
 		for (auto& [key, value] : _base) {
 			delta.insert(std::make_pair(key, value.get_delta()));
@@ -80,7 +82,7 @@ public:
 	}
 
 private:
-	std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>> _base;
+	std::map<k_type, Lattice<T, Func>> _base;
 };
 
 #endif // DELTASETMAP_H

--- a/include/TypeZoo/DeltaSetMap.hpp
+++ b/include/TypeZoo/DeltaSetMap.hpp
@@ -36,8 +36,16 @@ public:
 		return _base.at(key);
 	}
 
-	size_type size() {
+	const mapped_type& at(const key_type& key) const {
+		return _base.at(key);
+	}
+
+	size_type size() const {
 		return _base.size();
+	}
+
+	size_type count(const key_type& key) const {
+		return _base.count(key);
 	}
 
 	std::pair<iterator, bool> insert(const value_type& value) {

--- a/include/TypeZoo/DeltaSetMap.hpp
+++ b/include/TypeZoo/DeltaSetMap.hpp
@@ -1,0 +1,79 @@
+#ifndef DELTASETMAP_H
+#define DELTASETMAP_H
+
+#include "DeltaSet.hpp"
+#include <map>
+#include "lattice_core.hpp"
+#include "merges/map_mrg.hpp"
+
+template <typename k_type, typename set_v_type, class Func>
+class DeltaSetMap {
+public:
+
+	//type alias
+	using iterator = typename std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>::iterator;
+	using key_type = k_type;
+	using value_type = std::pair<k_type, Lattice<DeltaSet<set_v_type>, Func>>;
+	using size_type = std::size_t;
+	using delta_type = Lattice<DeltaSetMap<k_type, set_v_type, Func>, MapUnion>;
+
+	DeltaSetMap() : _base(std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>{}) {};
+
+	//copy constructor
+	DeltaSetMap(const std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>& base) : _base(base) {};
+
+	
+	iterator begin() {
+		return _base.begin();
+	}
+
+	iterator end() {
+		return _base.end();
+	}
+
+	size_type size() {
+		return _base.size();
+	}
+
+	std::pair<iterator, bool> insert(const value_type& value) {
+		return _base.insert(value);
+	}
+
+	std::pair<iterator, bool> insert(const value_type&& value) {
+		return _base.insert(value);
+	}
+
+	iterator erase(iterator pos) {
+		return _base.erase(pos);
+	}
+
+	template<class... Args>
+	std::pair<iterator, bool> emplace(Args&&... args) {
+		return _base.emplace(args...);
+	}
+
+	bool operator==(const DeltaSetMap<k_type, set_v_type, Func>& right) const {
+		return _base == right._base;
+	}
+
+	delta_type get_delta() {
+		DeltaSetMap<k_type, set_v_type, Func> delta;
+		
+		for (auto& [key, value] : _base) {
+			delta.insert(std::make_pair(key, value.get_delta()));
+		}
+
+		return Lattice(delta, MapUnion{});
+	}
+
+
+
+
+
+
+
+private:
+	std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>> _base;
+};
+
+#endif // DELTASETMAP_H

--- a/include/TypeZoo/DeltaSetMap.hpp
+++ b/include/TypeZoo/DeltaSetMap.hpp
@@ -13,6 +13,7 @@ public:
 	//type alias
 	using iterator = typename std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>>::iterator;
 	using key_type = k_type;
+	using mapped_type = Lattice<DeltaSet<set_v_type>, Func>;
 	using value_type = std::pair<k_type, Lattice<DeltaSet<set_v_type>, Func>>;
 	using size_type = std::size_t;
 	using delta_type = Lattice<DeltaSetMap<k_type, set_v_type, Func>, MapUnion>;
@@ -29,6 +30,10 @@ public:
 
 	iterator end() {
 		return _base.end();
+	}
+
+	mapped_type& at(const key_type& key) {
+		return _base.at(key);
 	}
 
 	size_type size() {
@@ -65,12 +70,6 @@ public:
 
 		return Lattice(delta, MapUnion{});
 	}
-
-
-
-
-
-
 
 private:
 	std::map<k_type, Lattice<DeltaSet<set_v_type>, Func>> _base;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB TEST_SRC
     "smoke/*.cpp"
 )
 
-add_executable(smoke catch.hpp ${TEST_SRC} smoke_morph/test_transformers.cpp smoke_type/deltaset_test.cpp)
+add_executable(smoke catch.hpp ${TEST_SRC} smoke_morph/test_transformers.cpp smoke_type/deltaset_test.cpp "smoke_type/deltasetmap_test.cpp")
 target_link_libraries(smoke arugula_lib)
 
 add_custom_target(valgrind

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB TEST_SRC
     "smoke/*.cpp"
 )
 
-add_executable(smoke catch.hpp ${TEST_SRC} smoke_morph/test_transformers.cpp smoke_type/deltaset_test.cpp "smoke_type/deltasetmap_test.cpp")
+add_executable(smoke catch.hpp ${TEST_SRC} smoke_morph/test_transformers.cpp smoke_type/deltaset_test.cpp smoke_type/deltasetmap_test.cpp)
 target_link_libraries(smoke arugula_lib)
 
 add_custom_target(valgrind

--- a/test/smoke/deltaset.cpp
+++ b/test/smoke/deltaset.cpp
@@ -3,7 +3,7 @@
 #include "merges/setop_mrg.hpp"
 #include "TypeZoo/DeltaSet.hpp"
 
-TEST_CASE("union_delta") {
+TEST_CASE("delta set with lattice union_delta") {
 	std::set<int> l({ 1, 20, 30 });
 	std::set<int> r({ 1, 2, 3 });
 

--- a/test/smoke/deltasetmap.cpp
+++ b/test/smoke/deltasetmap.cpp
@@ -1,11 +1,11 @@
 #include "../catch.hpp"
 #include "lattice_core.hpp"
 #include "TypeZoo/DeltaSet.hpp"
-#include "TypeZoo/DeltaSetMap.hpp"
+#include "TypeZoo/DeltaMap.hpp"
 #include "merges/setop_mrg.hpp"
 #include <iostream>
 
-TEST_CASE("deltasetmap with lattice mapunion test") {
+TEST_CASE("DeltaMap with lattice mapunion test") {
 	DeltaSet<int> t1(std::set<int>{1, 2, 3});
 	DeltaSet<int> t3(std::set<int>{1, 20, 30});
 	DeltaSet<int> t2(std::set<int>{5, 6, 7});
@@ -18,15 +18,15 @@ TEST_CASE("deltasetmap with lattice mapunion test") {
 
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> expected = { {"xx", Lattice(DeltaSet<int>(std::set<int>{20,30}), Union{})},
 																	{"yy", Lattice(DeltaSet<int>(std::set<int>{60,70}), Union{})} };
-	DeltaSetMap leftmap(left);
-	DeltaSetMap rightmap(right);
+	DeltaMap leftmap(left);
+	DeltaMap rightmap(right);
 	Lattice leftLattice(leftmap, MapUnion{});
 	Lattice rightLattice(rightmap, MapUnion{});
-	DeltaSetMap expectedmap(expected);
+	DeltaMap expectedmap(expected);
 	Lattice expectedLattice(expectedmap, MapUnion{});
 
 	leftLattice.merge(rightLattice);
-	DeltaSetMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftLattice.get_delta();
+	DeltaMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftLattice.get_delta();
 
 	REQUIRE(resultLattice == expectedLattice);
 	//verify the content of leftLattice after get delta

--- a/test/smoke/deltasetmap.cpp
+++ b/test/smoke/deltasetmap.cpp
@@ -1,0 +1,36 @@
+#include "../catch.hpp"
+#include "lattice_core.hpp"
+#include "TypeZoo/DeltaSet.hpp"
+#include "TypeZoo/DeltaSetMap.hpp"
+#include "merges/setop_mrg.hpp"
+#include <iostream>
+
+TEST_CASE("deltasetmap with lattice mapunion test") {
+	DeltaSet<int> t1(std::set<int>{1, 2, 3});
+	DeltaSet<int> t3(std::set<int>{1, 20, 30});
+	DeltaSet<int> t2(std::set<int>{5, 6, 7});
+	DeltaSet<int> t4(std::set<int>{5, 60, 70});
+
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> left = { {"xx", Lattice(t1, Union{})},
+																  {"yy", Lattice(t2, Union{})} };
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> right = { {"xx", Lattice(t3, Union{})},
+																  {"yy", Lattice(t4, Union{})} };
+
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> expected = { {"xx", Lattice(DeltaSet<int>(std::set<int>{20,30}), Union{})},
+																	{"yy", Lattice(DeltaSet<int>(std::set<int>{60,70}), Union{})} };
+	DeltaSetMap leftmap(left);
+	DeltaSetMap rightmap(right);
+	Lattice leftLattice(leftmap, MapUnion{});
+	Lattice rightLattice(rightmap, MapUnion{});
+	DeltaSetMap expectedmap(expected);
+	Lattice expectedLattice(expectedmap, MapUnion{});
+
+	leftLattice.merge(rightLattice);
+	DeltaSetMap<std::string, int, Union>::delta_type resultLattice = leftLattice.get_delta();
+
+	REQUIRE(resultLattice == expectedLattice);
+	//verify the content of leftLattice after get delta
+	REQUIRE(leftLattice.reveal().size() == 2);
+	REQUIRE(leftLattice.reveal().at("xx") == Lattice(DeltaSet<int>(std::set<int>{1, 2, 3, 20, 30}), Union{}));
+	REQUIRE(leftLattice.reveal().at("yy") == Lattice(DeltaSet<int>(std::set<int>{5, 6, 7, 60, 70}), Union{}));
+}

--- a/test/smoke/deltasetmap.cpp
+++ b/test/smoke/deltasetmap.cpp
@@ -26,7 +26,7 @@ TEST_CASE("deltasetmap with lattice mapunion test") {
 	Lattice expectedLattice(expectedmap, MapUnion{});
 
 	leftLattice.merge(rightLattice);
-	DeltaSetMap<std::string, int, Union>::delta_type resultLattice = leftLattice.get_delta();
+	DeltaSetMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftLattice.get_delta();
 
 	REQUIRE(resultLattice == expectedLattice);
 	//verify the content of leftLattice after get delta

--- a/test/smoke_type/deltasetmap_test.cpp
+++ b/test/smoke_type/deltasetmap_test.cpp
@@ -1,17 +1,17 @@
 #include "../catch.hpp"
 #include "lattice_core.hpp"
 #include "TypeZoo/DeltaSet.hpp"
-#include "TypeZoo/DeltaSetMap.hpp"
+#include "TypeZoo/DeltaMap.hpp"
 #include "merges/setop_mrg.hpp"
 #include <iostream>
 
 
-TEST_CASE("deltasetmap basic tests") {
+TEST_CASE("DeltaMap basic tests") {
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> left = { {"xx", Lattice(DeltaSet<int>(std::set<int>{1,2,3}), Union{})},
 																  {"yy", Lattice(DeltaSet<int>(std::set<int>{1,20,30}), Union{})} };
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> result;
-	DeltaSetMap leftmap(left);
-	DeltaSetMap resultmap(result);
+	DeltaMap leftmap(left);
+	DeltaMap resultmap(result);
 
 	//test basic functionalities
 	REQUIRE(leftmap.size() == 2);
@@ -36,11 +36,11 @@ TEST_CASE("delta test") {
 																  {"yy", Lattice(t2, Union{})}};
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> expected = { {"xx", Lattice(DeltaSet<int>(std::set<int>{20,30}), Union{})},
 																    {"yy", Lattice(DeltaSet<int>(std::set<int>{60,70}), Union{})} };
-	DeltaSetMap leftmap(left);
-	DeltaSetMap expectedmap(expected);
+	DeltaMap leftmap(left);
+	DeltaMap expectedmap(expected);
 	Lattice expectedLattice(expectedmap, MapUnion{});
 
-	DeltaSetMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftmap.get_delta();
+	DeltaMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftmap.get_delta();
 
 	REQUIRE(resultLattice == expectedLattice);
 }

--- a/test/smoke_type/deltasetmap_test.cpp
+++ b/test/smoke_type/deltasetmap_test.cpp
@@ -1,0 +1,40 @@
+#include "../catch.hpp"
+#include "lattice_core.hpp"
+#include "TypeZoo/DeltaSet.hpp"
+#include "TypeZoo/DeltaSetMap.hpp"
+#include "merges/setop_mrg.hpp"
+#include <iostream>
+
+
+TEST_CASE("basic tests") {
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> left = { {"xx", Lattice(DeltaSet<int>(std::set<int>{1,2,3}), Union{})},
+																  {"yy", Lattice(DeltaSet<int>(std::set<int>{1,20,30}), Union{})} };
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> result;
+	DeltaSetMap leftmap(left);
+	DeltaSetMap resultmap(result);
+
+	for (auto& e : leftmap) {
+		resultmap.insert(e);
+	}
+
+	REQUIRE(leftmap == resultmap);
+}
+
+TEST_CASE("delta test") {
+	DeltaSet<int> t1(std::set<int>{1, 2, 3});
+	t1.merge(DeltaSet<int>(std::set<int>{1, 20, 30}));
+	DeltaSet<int> t2(std::set<int>{5, 6, 7});
+	t2.merge(DeltaSet<int>(std::set<int>{5, 60, 70}));
+
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> left = { {"xx", Lattice(t1, Union{})},
+																  {"yy", Lattice(t2, Union{})}};
+	std::map<std::string, Lattice<DeltaSet<int>, Union>> expected = { {"xx", Lattice(DeltaSet<int>(std::set<int>{20,30}), Union{})},
+																    {"yy", Lattice(DeltaSet<int>(std::set<int>{60,70}), Union{})} };
+	DeltaSetMap leftmap(left);
+	DeltaSetMap expectedmap(expected);
+	Lattice expectedLattice(expectedmap, MapUnion{});
+
+	DeltaSetMap<std::string, int, Union>::delta_type resultLattice = leftmap.get_delta();
+
+	REQUIRE(resultLattice == expectedLattice);
+}

--- a/test/smoke_type/deltasetmap_test.cpp
+++ b/test/smoke_type/deltasetmap_test.cpp
@@ -6,13 +6,19 @@
 #include <iostream>
 
 
-TEST_CASE("basic tests") {
+TEST_CASE("deltasetmap basic tests") {
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> left = { {"xx", Lattice(DeltaSet<int>(std::set<int>{1,2,3}), Union{})},
 																  {"yy", Lattice(DeltaSet<int>(std::set<int>{1,20,30}), Union{})} };
 	std::map<std::string, Lattice<DeltaSet<int>, Union>> result;
 	DeltaSetMap leftmap(left);
 	DeltaSetMap resultmap(result);
 
+	//test basic functionalities
+	REQUIRE(leftmap.size() == 2);
+	REQUIRE(leftmap.count("xx") == 1);
+	REQUIRE(leftmap.at("xx") == Lattice(DeltaSet<int>(std::set<int>{1, 2, 3}), Union{}));
+
+	//test the iterator
 	for (auto& e : leftmap) {
 		resultmap.insert(e);
 	}

--- a/test/smoke_type/deltasetmap_test.cpp
+++ b/test/smoke_type/deltasetmap_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE("delta test") {
 	DeltaSetMap expectedmap(expected);
 	Lattice expectedLattice(expectedmap, MapUnion{});
 
-	DeltaSetMap<std::string, int, Union>::delta_type resultLattice = leftmap.get_delta();
+	DeltaSetMap<std::string, DeltaSet<int>, Union>::delta_type resultLattice = leftmap.get_delta();
 
 	REQUIRE(resultLattice == expectedLattice);
 }


### PR DESCRIPTION
Implemented DeltaSetMap: This is a class that wrap std::map with added restriction and comply with the has_delta type trait. This class must map to a Lattice with DeltaSet as domain. When get_delta is called on this class, it will construct a new DeltaSetMap by calling get_delta() on each of its value, and return a Lattice<DeltaSetMap, MapUnion> using the newly constructed DeltaSetMap. This class is both unit tested and tested using Lattice. It is designed to have a compatible interface with std::map.